### PR TITLE
Allow MariaDB to be treated like MySQL

### DIFF
--- a/index.php
+++ b/index.php
@@ -62,7 +62,8 @@ $xmlbutton = html_writer::empty_tag('img', array(
     'alt' => get_string('xmlview', 'local_upgradedb'), 'class' => 'iconsmall'));
 
 $ismysql = 0;
-if ($CFG->dbtype == 'mysqli') {
+$compatdb = array("mysqli","mariadb");
+if (in_array($CFG->dbtype,$compatdb)) {
     $ismysql = 1;
 }
 


### PR DESCRIPTION
Expand list of dbtypes to be considered MySQL alike. Now "mysqli" and "mariadb" are accepted.
